### PR TITLE
Added the keyboard shortcut `ALT`+`SHIFT`+`S` to open SAML-tracer or …

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Using SAML-tracer
 -----------------
 
 SAML-tracer is activated by clicking its icon in the browser toolbar.
+It can be alternatively started by pressing <kbd>ALT</kbd> +
+<kbd>SHIFT</kbd> + <kbd>S</kbd> on the keyboard.
 
 Once it is activated, you will get a window that shows all requests,
 and the data included in them. It also shows response headers.

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,13 @@
       "96": "src/resources/images/icon96.png",
       "128": "src/resources/images/icon128.png"
     }
+  },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+S"
+      },
+      "description": "Opens SAML-tracer if it's not yet started or brings it back to the front if it's already started."
+    }
   }
 }


### PR DESCRIPTION
…bring it back to front if it's already started. This fixes issue #60.

Maybe have a look at the API documentation:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands
https://developer.chrome.com/apps/commands