### PR TITLE
The escape sequence '\?' is equivalent to just '?'

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -162,27 +162,9 @@ SAMLTrace.Request.prototype = {
       return;
     }
 
-    var r = new RegExp('[&;\?]');
-    var elements = this.url.split(r);
-
     this.get = [];
-
-    for (var i = 1; i < elements.length; i++) {
-      var e = elements[i];
-      var p = e.indexOf('=');
-      var name, value;
-      if (p == -1) {
-        name = e;
-        value = '';
-      } else {
-        name = e.substr(0, p);
-        value = e.substr(p + 1);
-      }
-
-      name = name.replace('+', ' ');
-      name = decodeURIComponent(name);
-      value = value.replace('+', ' ');
-      value = decodeURIComponent(value);
+    // URLSearchParams handles splitting and decoding: https://url.spec.whatwg.org/#concept-urlencoded-parser
+    for (const [name, value] of new URL(this.url).searchParams.entries()) {
       this.get.push([name, value]);
     }
   },


### PR DESCRIPTION
Recently I played around with GitHub Actions [in my SAML-tracer fork](https://github.com/khlr/SAML-tracer/security/code-scanning/1) and came to know that there's a useless backslash in the regular expression for parsing the query string of GET requests:

> The escape sequence '\\?' is equivalent to just '?', so the sequence may still represent a meta-character when it is used in a regular expression.
>
> Tool CodeQL, Rule ID js/useless-regexp-character-escape

Instead of parsing the query string manually, SAML-tracer can make use of `URLSearchParams` which greatly facilitates the process.

But there's one thing that made me wonder: Does anyone know why there's been a semicolon in the regular expression?

```js
var r = new RegExp('[&;\?]');
```

It's clear that one would want an URL to be split on `?` and `&` to get the name value pairs of the query string. But why should it be split on `;` as well??