### PR TITLE
Remove Dependency on InstallTrigger. Replacement is OnBeforeSendHeade…

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -904,18 +904,6 @@ SAMLTrace.TraceWindow.init = function() {
   var browser = browser || chrome;
   let traceWindow = new SAMLTrace.TraceWindow();
 
-  let isFirefox = () => {
-    return typeof InstallTrigger !== 'undefined';
-  }
-
-  let getOnBeforeSendHeadersExtraInfoSpec = () => {
-    return isFirefox() ? ["blocking", "requestHeaders"] : ["blocking", "requestHeaders", "extraHeaders"];
-  };
-
-  let getOnHeadersReceivedExtraInfoSpec = () => {
-    return isFirefox() ? ["blocking", "responseHeaders"] : ["blocking", "responseHeaders", "extraHeaders"];
-  };
-
   browser.webRequest.onBeforeRequest.addListener(
     traceWindow.saveNewRequest,
     {urls: ["<all_urls>"]},
@@ -925,13 +913,13 @@ SAMLTrace.TraceWindow.init = function() {
   browser.webRequest.onBeforeSendHeaders.addListener(
     traceWindow.attachHeadersToRequest,
     {urls: ["<all_urls>"]},
-    getOnBeforeSendHeadersExtraInfoSpec()
+    ['blocking', 'requestHeaders', browser.webRequest.OnBeforeSendHeadersOptions.EXTRA_HEADERS].filter(Boolean)
   );
-
+  
   browser.webRequest.onHeadersReceived.addListener(
     traceWindow.attachResponseToRequest,
     {urls: ["<all_urls>"]},
-    getOnHeadersReceivedExtraInfoSpec()
+    ['blocking', 'responseHeaders', browser.webRequest.OnHeadersReceivedOptions.EXTRA_HEADERS].filter(Boolean)
   );
 };
 

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -915,7 +915,7 @@ SAMLTrace.TraceWindow.init = function() {
     {urls: ["<all_urls>"]},
     ['blocking', 'requestHeaders', browser.webRequest.OnBeforeSendHeadersOptions.EXTRA_HEADERS].filter(Boolean)
   );
-  
+
   browser.webRequest.onHeadersReceived.addListener(
     traceWindow.attachResponseToRequest,
     {urls: ["<all_urls>"]},


### PR DESCRIPTION
…rsOptions.EXTRA_HEADERS and OnHeadersReceivedOptions.EXTRA_HEADERS predefined constants.

This fixes #74, implementing Chrome-specific checks to predefined constants that return 'extraHeaders' for Chrome only, and are undefined for other browsers, which we can then filter. 