### PR TITLE
Fix typos not found by codespell

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -808,7 +808,7 @@ SAMLTrace.TraceWindow.prototype = {
 
         var isVisible = tracer.isRequestVisible(response);
         if (!isVisible) {
-          requestDiv.classList.add("isRessource");
+          requestDiv.classList.add("isResource");
           
           if (!tracer.filterResources) {
             requestDiv.classList.add("displayAnyway");

--- a/src/exportDialog.js
+++ b/src/exportDialog.js
@@ -7,7 +7,7 @@ ui = {
   exportResult: null,
 
   bindButtons: () => {
-    // bind radio huttons
+    // bind radio buttons
     let radioButtons = document.querySelectorAll('input[type="radio"]');
     Array.from(radioButtons).map(rb => rb.onchange = e => ui.createExportResult());
 
@@ -23,12 +23,12 @@ ui = {
     }, true);
   },
 
-  setupContent: (requests, httpRequests, isFlteringActive) => {
+  setupContent: (requests, httpRequests, isFilteringActive) => {
     // remember the currently captured (and filtered) requests
     if (requests) {
       let filteredRequests = requests.filter(req => {
         let match = httpRequests.find(hr => hr.req.requestId === req.requestId);
-        if (match && (match.isVisible || !isFlteringActive)) {
+        if (match && (match.isVisible || !isFilteringActive)) {
           return req;
         }
       });

--- a/src/resources/css/samltrace.css
+++ b/src/resources/css/samltrace.css
@@ -107,11 +107,11 @@ a.tab:hover {
   color: #96C8F5;
   background-color: #0074e8;
 }
-.list-row.isRessource {
+.list-row.isResource {
   height: 0;
   border-bottom: none;
 }
-.list-row.isRessource.displayAnyway {
+.list-row.isResource.displayAnyway {
   height: unset;
   border-bottom: 1px dotted #cccccc;
 }
@@ -122,7 +122,7 @@ a.tab:hover {
 }
 
 .request-url {
-  /* fullwidth minus HTTP-method width minus SAML- and WS-Fed-logo */
+  /* full width minus HTTP-method width minus SAML- and WS-Fed-logo */
   width: calc(100% - 5em - 40px - 56px);
 }
 

--- a/src/scrollableList.js
+++ b/src/scrollableList.js
@@ -6,7 +6,7 @@ if ("undefined" === typeof(ScrollableList)) {
   var ScrollableList = new function() {
 
     const isElementToBeSkipped = elem => {
-      return elem && elem.classList.contains("isRessource") && !elem.classList.contains("displayAnyway");
+      return elem && elem.classList.contains("isResource") && !elem.classList.contains("displayAnyway");
     };
 
     const getSibling = (cur, siblingFunc) => {
@@ -66,7 +66,7 @@ if ("undefined" === typeof(ScrollableList)) {
       }
     };
 
-    this.selectRowOnKeybeardEvent = (e, list, onNewElementSelected) => {
+    this.selectRowOnKeyboardEvent = (e, list, onNewElementSelected) => {
       this.list = list;
       let newElement = null;
       let selectedElement = this.list.querySelector(".selected");

--- a/src/ui.js
+++ b/src/ui.js
@@ -70,7 +70,7 @@ ui = {
     document.getElementById("button-filter").addEventListener("click", e => {
       let newState = ui.toggleButtonState(e.target);
       window.tracer.setFilterResources(newState);
-      let hidableRows = document.getElementsByClassName("list-row isRessource");
+      let hidableRows = document.getElementsByClassName("list-row isResource");
       if (newState) {
         Array.from(hidableRows).forEach(row => row.classList.remove("displayAnyway"));
       } else {
@@ -90,9 +90,9 @@ ui = {
     document.getElementById("button-export-list").addEventListener("click", () => {
       let exportDialog = document.getElementById("exportDialog");
       exportDialog.style.visibility = "visible";
-      let isFlteringActive = document.getElementById("button-filter").classList.contains("active");
+      let isFilteringActive = document.getElementById("button-filter").classList.contains("active");
       let exportDialogContent = document.getElementById("exportDialogContent");
-      exportDialogContent.contentWindow.ui.setupContent(window.tracer.requests, window.tracer.httpRequests, isFlteringActive);
+      exportDialogContent.contentWindow.ui.setupContent(window.tracer.requests, window.tracer.httpRequests, isFilteringActive);
     }, true);
     document.getElementById("button-import-list").addEventListener("click", () => {
       let importDialog = document.getElementById("importDialog");
@@ -124,10 +124,10 @@ ui = {
       }
     };
 
-    const selectRowOnKeybeardEvent = e => {
+    const selectRowOnKeyboardEvent = e => {
       // select another request, when ArrowUp, ArrowDown, PageUp, PageDown, Home or End are pressed
       let requestList = document.getElementById("request-list");
-      ScrollableList.selectRowOnKeybeardEvent(e, requestList, newElement => {
+      ScrollableList.selectRowOnKeyboardEvent(e, requestList, newElement => {
         window.tracer.selectItemInList(newElement, requestList);
         window.tracer.showRequest(newElement.requestItem);
         ui.highlightContent();
@@ -147,7 +147,7 @@ ui = {
     iframes.forEach(iframe => iframe.contentWindow.document.addEventListener("keydown", closeDialogs));
     document.addEventListener("keydown", closeDialogs);
     document.addEventListener("keydown", selectRequestInfoContent);
-    document.addEventListener("keydown", selectRowOnKeybeardEvent);
+    document.addEventListener("keydown", selectRowOnKeyboardEvent);
     document.addEventListener("keydown", togglePauseTracing);
   },
 


### PR DESCRIPTION
Ressource → Resource
Fltering → Filtering
Keybeard → Keyboard

This change actual names in code, not comments. As far as I can see, these typos do not depend on similar typos in dependencies.