### PR TITLE
Manifest V3 update.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -60,7 +60,7 @@ git archive --format tar "$RELEASE" | (cd "$DEST"; tar xv)
 
 cd "$DEST"
 
-zip -r "$TARGET" *
+zip -1 -r "$TARGET" *
 
 cd /
 rm -rf "$DEST"

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,7 +3,7 @@
 // The onOpenWindow event handler was slightly modified to be compatible with standard Firefox.
 
 var browser = browser || chrome
-browser.browserAction.onClicked.addListener((tab) => showTracerWindow());
+browser.action.onClicked.addListener((tab) => showTracerWindow());
 
 var tracerWindow = null;
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,12 @@
       "128": "src/resources/images/icon128.png"
     }
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}",
+      "strict_min_version": "109.0"
+    }
+  },
   "commands": {
     "_execute_action": {
       "suggested_key": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML-tracer",
   "description": "A debugger for viewing SAML messages",
-  "author": "Olav Morken, Jaime Perez, Thijs Kinkhorst, Jan Köhler",
+  "author": "Olav Morken, Jaime Perez, Thijs Kinkhorst, Jan Köhler, Tim van Dijen",
   "manifest_version": 3,
   "version": "1.8.0",
   "homepage_url": "https://github.com/SimpleSAMLphp/SAML-tracer",
@@ -19,7 +19,8 @@
     "<all_urls>"
   ],
   "background": {
-    "service_worker": "bootstrap.js"
+    "service_worker": "bootstrap.js",
+    "scripts": ["bootstrap.js"]
   },
   "action": {
     "default_icon": {
@@ -33,7 +34,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}",
-      "strict_min_version": "109.0"
+      "strict_min_version": "121.0"
     }
   },
   "commands": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "SAML-tracer",
   "description": "A debugger for viewing SAML messages",
   "author": "Olav Morken, Jaime Perez, Thijs Kinkhorst, Jan Köhler",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "version": "1.8.0",
   "homepage_url": "https://github.com/SimpleSAMLphp/SAML-tracer",
   "icons": {
@@ -13,14 +13,15 @@
     "128": "src/resources/images/icon128.png"
   },
   "permissions": [
-    "webRequest",
-    "webRequestBlocking",
+    "webRequest"
+  ],
+  "host_permissions": [
     "<all_urls>"
   ],
   "background": {
-    "scripts": ["bootstrap.js"]
+    "service_worker": "bootstrap.js"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "src/resources/images/icon16.png",
       "32": "src/resources/images/icon32.png",
@@ -30,7 +31,7 @@
     }
   },
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Alt+Shift+S"
       },

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -905,19 +905,19 @@ SAMLTrace.TraceWindow.init = function() {
   browser.webRequest.onBeforeRequest.addListener(
     traceWindow.saveNewRequest,
     {urls: ["<all_urls>"]},
-    ["blocking", "requestBody"]
+    ["requestBody"]
   );
 
   browser.webRequest.onBeforeSendHeaders.addListener(
     traceWindow.attachHeadersToRequest,
     {urls: ["<all_urls>"]},
-    ['blocking', 'requestHeaders', browser.webRequest.OnBeforeSendHeadersOptions.EXTRA_HEADERS].filter(Boolean)
+    ['requestHeaders', browser.webRequest.OnBeforeSendHeadersOptions.EXTRA_HEADERS].filter(Boolean)
   );
 
   browser.webRequest.onHeadersReceived.addListener(
     traceWindow.attachResponseToRequest,
     {urls: ["<all_urls>"]},
-    ['blocking', 'responseHeaders', browser.webRequest.OnHeadersReceivedOptions.EXTRA_HEADERS].filter(Boolean)
+    ['responseHeaders', browser.webRequest.OnHeadersReceivedOptions.EXTRA_HEADERS].filter(Boolean)
   );
 };
 


### PR DESCRIPTION
I took a stab at Issue #79. For the most part this was a straightforward, following the Chrome [Migration Path](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration). 

## Changes

- browserAction has been replaced by a [more generic action](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification).
- there are some permissions changes, namely that '<all_urls>' is now a [host permission](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#host-permissions) and that we don't need webRequestBlocking (see note below re: the [reviseRedirectedRequestMethod](https://github.com/simplesamlphp/SAML-tracer/blob/main/src/SAMLTrace.js#L707) issue) raised in #79 by @khlr.
- we now refer the background script as a "service worker" instead of a background script

## Notes

- We **do not want to merge this now** to main, as Manifest V3 is unsupported by Firefox at the moment, though will be out [later this year](https://blog.mozilla.org/addons/2022/05/18/manifest-v3-in-firefox-recap-next-steps/). I think it may make sense to keep this around in a feature branch until then, however, so I'm contributing the code I have now. 
  - I checked and even my Firefox Dev Edition (104.0b3), which has an `about:config` option (`extensions.manifestV3.enabled`) to "support" MV3, doesn't yet support service workers... so we're kind of dead in the water with MV3 development at the moment.

 - Re: the necessity of blocking permissions for [reviseRedirectedRequestMethod](https://github.com/simplesamlphp/SAML-tracer/blob/main/src/SAMLTrace.js#L707)

   - I took a look at where the requirement for this code came from in the [original issue](https://github.com/SimpleSAMLphp/SAML-tracer/pull/23#issuecomment-345540591) cited within the code, and referencing [this StackOverflow post](https://stackoverflow.com/questions/47379439/webrequest-api-redirect-uses-http-method-of-parent-request) and I have to be completely honest here, try as a I might I was unable to replicate. Obviously, I'm not leveraging the versions of Chrome and FF from back then, but despite throwing many test cases of POSTs followed by GETs I did not see untracked requests within SAML-Tracer.

   - That said, that *does not prove* that we don't have an issue. *The absence of evidence is not the evidence of absence.* In particular, either (a) webRequest has changed since that time, or (b) I'm not replicating the issue correctly.

   - Re: (a), I'm not in a position to comment since I've not done this research. :wink:

   - Re: (b), I'm not in a position to comment since *I'm* the cause of that issue.

   - For what it's worth, I think there's a *strong* likelihood that I'm not replicating the previous issue correctly... but I will expound on what I did:

     - I tested with the https://wiki.surfnet.nl/ SP, as described in the original issue: https://github.com/SimpleSAMLphp/SAML-tracer/pull/23#issuecomment-344970423

     - I tested with my own Shibboleth and SimpleSAMLphp dev environment and forcing POSTs followed by GETs.

     - I tested with two Shibboleth IDPs that are configured as proxied instances to upstream IDPs... one a "production" quality system I maintain that upstreams to Okta, and another my development proxy instance running in Azure that's got a selectable selection of upstreams (Shibboleth, WSO2 IS, Azure, and Keycloak).

     - At no point with ANY of these was I able to "break" things insofar as non-tracked SAML assertions being logged.

  - So while I do not want to say with 100% certainty that "it's working", I would be relatively comfortable stating that I have some degree of confidence that it's working, and that I think the next step is for some others to test to confirm my findings / validate that they can't replicate.
 
 - And lastly, by "replicate" I should also clarify to mean that I cannot get [these lines of code](https://github.com/simplesamlphp/SAML-tracer/blob/55dd45c5b9527f3308482b6bc48ebf3294f5e73b/src/SAMLTrace.js#L722-L725) to activate under any of the test circumstances described above.