### PR TITLE
Bugfix/fix mask values

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -109,7 +109,7 @@ SAMLTraceIO_filters.genMultiValueFilter = function(collection, key, separator, n
       return;
     }
 
-    let elem = req[collection].find(item => item.name === key);
+    let elem = req[collection].find(item => item.name.toUpperCase() === key.toUpperCase());
     if (elem == null) {
       return;
     }

--- a/src/filters.js
+++ b/src/filters.js
@@ -89,7 +89,7 @@ SAMLTraceIO_filters.obfuscateValueFilter = function(collection, key) {
 * i.e.
 *   myfilter = SAMLTraceIO_filters.overwriteCookieValueFilter(
 *     'requestHeaders', 'Cookie', '{overwritten}');
-* will return a function that can called with a SAMLTrace.Request instance
+* will return a function that can be called with a SAMLTrace.Request instance
 * as argument, and will filter based on provided parameters,
 * i.e.
 *   filtered_request = myfilter(unfiltered_request);
@@ -116,26 +116,26 @@ SAMLTraceIO_filters.genMultiValueFilter = function(collection, key, separator, n
 
     for (let index = 0; index < elems.length; index++) {
       let elem = elems[index];
-      let ac = elem.value.split(separator);
-      let fc = [];
+      let originalKeyValuePairs = elem.value.split(separator);
+      let processedKeyValuePairs = [];
   
-      for (let i = 0; i < ac.length; i++) {
-        let kk,kv;
-        if (ac[i].indexOf('=')>=0) {
-          kk=ac[i].split('=')[0];
-          kv=ac[i].split('=')[1];
+      for (let i = 0; i < originalKeyValuePairs.length; i++) {
+        let subkey, subvalue;
+        if (originalKeyValuePairs[i].indexOf('=') >= 0) {
+          subkey = originalKeyValuePairs[i].split('=')[0];
+          subvalue = originalKeyValuePairs[i].split('=')[1];
         } else {
-          kk='';// no key
-          kv=ac[i];
+          subkey = '';// no key
+          subvalue = originalKeyValuePairs[i];
         }
   
-        new_val_func(kk, kv, (kkk, newval) => {
+        new_val_func(subkey, subvalue, (processedSubkey, newval) => {
           // create syntactically correct entry:
-          fc.push([kkk, newval].join('='));
+          processedKeyValuePairs.push([processedSubkey, newval].join('='));
   
           // update element's value on the last iteration
-          if (i === ac.length - 1) {
-            elem.value = fc.join(separator);
+          if (i === originalKeyValuePairs.length - 1) {
+            elem.value = processedKeyValuePairs.join(separator);
           }
         });
       } 

--- a/src/filters.js
+++ b/src/filters.js
@@ -125,13 +125,17 @@ SAMLTraceIO_filters.genMultiValueFilter = function(collection, key, separator, n
           subkey = originalKeyValuePairs[i].split('=')[0];
           subvalue = originalKeyValuePairs[i].split('=')[1];
         } else {
-          subkey = '';// no key
-          subvalue = originalKeyValuePairs[i];
+          subkey = originalKeyValuePairs[i];
+          subvalue = null; // no value for boolean/flag-attributes
         }
   
         new_val_func(subkey, subvalue, (processedSubkey, newval) => {
           // create syntactically correct entry:
-          processedKeyValuePairs.push([processedSubkey, newval].join('='));
+          if (subvalue !== null) {
+            processedKeyValuePairs.push([processedSubkey, newval].join('='));
+          } else {
+            processedKeyValuePairs.push(processedSubkey);
+          }
   
           // update element's value on the last iteration
           if (i === originalKeyValuePairs.length - 1) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -109,33 +109,36 @@ SAMLTraceIO_filters.genMultiValueFilter = function(collection, key, separator, n
       return;
     }
 
-    let elem = req[collection].find(item => item.name.toUpperCase() === key.toUpperCase());
-    if (elem == null) {
+    const elems = req[collection].filter(item => item.name.toUpperCase() === key.toUpperCase());
+    if (elems == null || elems.length === 0) {
       return;
     }
-    
-    var ac = elem.value.split(separator);
-    var fc = [];
 
-    for (let i = 0; i < ac.length; i++) {
-      var kk,kv;
-      if (ac[i].indexOf('=')>=0) {
-        kk=ac[i].split('=')[0];
-        kv=ac[i].split('=')[1];
-      } else {
-        kk='';// no key
-        kv=ac[i];
-      }
-
-      new_val_func(kk, kv, (kkk, newval) => {
-        // create syntactically correct entry:
-        fc.push([kkk, newval].join('='));
-
-        // update element's value on the last iteration
-        if (i === ac.length - 1) {
-          elem.value = fc.join(separator);
+    for (let index = 0; index < elems.length; index++) {
+      let elem = elems[index];
+      let ac = elem.value.split(separator);
+      let fc = [];
+  
+      for (let i = 0; i < ac.length; i++) {
+        let kk,kv;
+        if (ac[i].indexOf('=')>=0) {
+          kk=ac[i].split('=')[0];
+          kv=ac[i].split('=')[1];
+        } else {
+          kk='';// no key
+          kv=ac[i];
         }
-      });
+  
+        new_val_func(kk, kv, (kkk, newval) => {
+          // create syntactically correct entry:
+          fc.push([kkk, newval].join('='));
+  
+          // update element's value on the last iteration
+          if (i === ac.length - 1) {
+            elem.value = fc.join(separator);
+          }
+        });
+      } 
     }
   };
 }


### PR DESCRIPTION
This PR fixes issue #88.

* The key comparison is now case-insensitive
* Multiple headers with same key (e.g. `Set-Cookie`) are now all processed

What I've done additionally:
* I have replaced the short, hard to read variable names with longer but more meaningful names. (https://github.com/simplesamlphp/SAML-tracer/commit/e2e2c0cee2afdadee29f3cd9cc5ed31724c96c64)
* I changed the behavior for boolean/flag-attributes: They are no longer considered as values but as keys, which means that they are not changed in the output. Until now, the Secure-flag, for example, produced the unattractive or "wrong" result `...9e91};={hash:a08203914d84eb};Domain=...`. Instead, the output now looks like this: `...9e91};Secure;Domain=...` (https://github.com/simplesamlphp/SAML-tracer/commit/27d386624298657caec79a7a839b6c151476131c)

What I didn't do:
* I didn't change anything for Firefox specifically. Which means that the "very special bahaviour" (`\n`, see [here](https://github.com/simplesamlphp/SAML-tracer/issues/88#issuecomment-1783784335)) remains...