### PR TITLE
Added Properties-syntax of highlight.js

### DIFF
--- a/lib/highlight.min.js
+++ b/lib/highlight.min.js
@@ -319,7 +319,16 @@ contains:s}},{begin:"(?=^[A-Z]+ (.*?) "+n+"$)",end:/$/,contains:[{
 className:"string",begin:" ",end:" ",excludeBegin:!0,excludeEnd:!0},{
 className:"meta",begin:n},{className:"keyword",begin:"[A-Z]+"}],starts:{
 end:/\b\B/,illegal:/\S/,contains:s}},e.inherit(a,{relevance:0})]}}})()
-;hljs.registerLanguage("http",e)})();/*! `xml` grammar compiled for Highlight.js 11.9.0 */
+;hljs.registerLanguage("http",e)})();/*! `properties` grammar compiled for Highlight.js 11.9.0 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const n="[ \\t\\f]*",t=n+"[:=]"+n,s="[ \\t\\f]+",a="([^\\\\:= \\t\\f\\n]|\\\\.)+",r={
+end:"("+t+"|"+s+")",relevance:0,starts:{className:"string",end:/$/,relevance:0,
+contains:[{begin:"\\\\\\\\"},{begin:"\\\\\\n"}]}};return{name:".properties",
+disableAutodetect:!0,case_insensitive:!0,illegal:/\S/,
+contains:[e.COMMENT("^\\s*[!#]","$"),{returnBegin:!0,variants:[{begin:a+t},{
+begin:a+s}],contains:[{className:"attr",begin:a,endsParent:!0}],starts:r},{
+className:"attr",begin:a+n+"$"}]}}})();hljs.registerLanguage("properties",e)
+})();/*! `xml` grammar compiled for Highlight.js 11.9.0 */
 (()=>{var e=(()=>{"use strict";return e=>{
 const a=e.regex,n=a.concat(/[\p{L}_]/u,a.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),s={
 className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},t={begin:/\s/,

--- a/src/ui.js
+++ b/src/ui.js
@@ -185,12 +185,12 @@ ui = {
   
   highlightContent: () => {
     const getSyntaxHighlightingClass = tab => {
-      let tabName = tab ? tab.href.split('#')[1] : "n/a";
-      if (tabName === "HTTP" || tabName === "Parameters") {
-        return "HTTP";
-      } else {
-        return "XML";
-      }
+      const tabName = tab ? tab.href.split('#')[1] : 'n/a';
+      return {
+        'HTTP': 'HTTP',
+        'Parameters': 'Properties',
+        'SAML': 'XML'
+      }[tabName];
     };
 
     const removeSyntaxHighlightingClasses = block => {


### PR DESCRIPTION
This PR fixes issue #83.

Contents of the Parameters-tab are now highlighted correctly using the parameters-language of hljs.