### PR TITLE
Issue 98 - Handle undefined content type header when evaluating visibility

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -601,7 +601,7 @@ SAMLTrace.TraceWindow = function() {
 SAMLTrace.TraceWindow.prototype = {
   'isRequestVisible' : function(request) {
     const contentTypeHeader = request.responseHeaders.find(header => header.name.toLowerCase() === 'content-type');
-    if (contentTypeHeader === null) {
+    if (!contentTypeHeader) {
       return true;
     }
     const type = contentTypeHeader.value.split(';')[0].toLowerCase().trim();


### PR DESCRIPTION
This change, which handles the case where contentTypeHeader is undefined in isRequestVisible (which it often is in my use case), fixes issue 98, the export problem. It also eliminates a bunch of unhandled exception cases in the console.