### PR TITLE
Functionality for filtering for protocol-related requests only

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -562,6 +562,9 @@ SAMLTrace.RequestItem.prototype = {
     var uniqueRequestId = new SAMLTrace.UniqueRequestId(this.request.requestId, this.request.method, this.request.url);
     uniqueRequestId.create(id => hbox.setAttribute('id', id));
     hbox.setAttribute('class', 'list-row');
+    if (this.request.protocol) {
+      hbox.classList.add('is-protocol');
+    }
     hbox.appendChild(methodLabel);
     hbox.appendChild(urlLabel);
 
@@ -594,15 +597,16 @@ SAMLTrace.TraceWindow = function() {
   this.requests = [];
   this.pauseTracing = false;
   this.autoScroll = true;
-  this.filterResources = true;
+  this.hideResources = true;
+  this.showProtocolOnly = false;
   this.colorizeRequests = true;
 };
 
 SAMLTrace.TraceWindow.prototype = {
-  'isRequestVisible' : function(request) {
+  'isRequestResource' : function(request) {
     const contentTypeHeader = request.responseHeaders.find(header => header.name.toLowerCase() === 'content-type');
-    if (contentTypeHeader === null) {
-      return true;
+    if (!contentTypeHeader) {
+      return false;
     }
     const type = contentTypeHeader.value.split(';')[0].toLowerCase().trim();
     const basetype = type.split('/')[0];
@@ -612,7 +616,7 @@ SAMLTrace.TraceWindow.prototype = {
     case 'font':
     case 'image':
     case 'video':
-      return false;
+      return true;
     }
 
     // Some of the below are deprecated variants, but we keep them as
@@ -630,21 +634,23 @@ SAMLTrace.TraceWindow.prototype = {
     case 'application/font-woff2':
     case 'application/x-font-ttf':
     case 'application/x-font-woff':
+    case 'font/woff2':
     case 'text/css':
     case 'text/ecmascript':
     case 'text/javascript':
     case 'text/x-content-security-policy':
-      return false;
+      return true;
     }
 
-    return true;
+    return false;
   },
 
   'addRequestItem' : function(request, getResponse) {
     var samlTracerRequest = new SAMLTrace.Request(request, getResponse);
-    var item = new SAMLTrace.RequestItem(samlTracerRequest, showContentElement);
     this.requests.push(samlTracerRequest);
+    request.parsed = samlTracerRequest;
 
+    var item = new SAMLTrace.RequestItem(samlTracerRequest, showContentElement);
     var requestList = document.getElementById('request-list');
     var showContentElement = document.getElementById('request-info-content');
     var requestItemListElement = item.addListItem(requestList, showContentElement);
@@ -683,8 +689,13 @@ SAMLTrace.TraceWindow.prototype = {
     this.autoScroll = autoScroll;
   },
 
-  'setFilterResources' : function(filterResources) {
-    this.filterResources = filterResources;
+  'setHideResources' : function(hideResources) {
+    this.hideResources = hideResources;
+    this.updateStatusBar();
+  },
+
+  'setShowProtocolOnly' : function(showProtocolOnly) {
+    this.showProtocolOnly = showProtocolOnly;
     this.updateStatusBar();
   },
 
@@ -693,12 +704,14 @@ SAMLTrace.TraceWindow.prototype = {
   },
 
   'updateStatusBar' : function() {
-    var hiddenElementsString = "";
-    if (this.filterResources) {
-      hiddenElementsString = ` (${this.httpRequests.filter(req => typeof req.isVisible !== "undefined" && !req.isVisible).length} hidden)`;
+    let hiddenElementsString = "";
+    if (this.hideResources || this.showProtocolOnly) {
+      const invisibleItems = this.httpRequests.filter(req => (req.isVisible && !req.isVisible(this.hideResources, this.showProtocolOnly)));
+      hiddenElementsString = ` (${invisibleItems.length} hidden)`;
     }
-    var status = `${this.httpRequests.length} requests received ${hiddenElementsString}`;
-    var statusItem = document.getElementById('statuspanel');
+    
+    const status = `${this.httpRequests.length} requests received ${hiddenElementsString}`;
+    const statusItem = document.getElementById('statuspanel');
     statusItem.innerText = status;
   },
 
@@ -784,6 +797,11 @@ SAMLTrace.TraceWindow.prototype = {
       }
 
       entry.res = response;
+      entry.isVisible = function(hideResources, showProtocolRequestsOnly) {
+        const isHiddenByResource = hideResources && entry.isResource;
+        const isHiddenByProtocol = showProtocolRequestsOnly && !entry.parsed?.protocol;      
+        return !(isHiddenByResource || isHiddenByProtocol);
+      };
 
       // layout update: apply style to item based on responseStatus
       let status = 'other';
@@ -800,24 +818,28 @@ SAMLTrace.TraceWindow.prototype = {
       };
 
       var requestDiv = document.getElementById(id);
-      if (requestDiv !== null) {
+      if (requestDiv) {
         removeClassByPrefix(requestDiv, "request-");
         requestDiv.classList.add("request-" + status);
 
-        var isVisible = tracer.isRequestVisible(response);
-        if (!isVisible) {
-          requestDiv.classList.add("isResource");
-          
-          if (!tracer.filterResources) {
-            requestDiv.classList.add("displayAnyway");
+        var isResource = tracer.isRequestResource(response);
+        entry.isResource = isResource;
+        if (isResource) {
+          requestDiv.classList.add("is-resource");
+        
+          if (!tracer.hideResources) {
+            requestDiv.classList.add("show-resource");
           }
+        }
+
+        if (!entry.parsed.protocol && tracer.showProtocolOnly) {
+          requestDiv.classList.add("non-protocol");
         }
 
         if (!tracer.colorizeRequests) {
           requestDiv.classList.add("monochrome");
         }
-        
-        entry.isVisible = isVisible;
+
         tracer.updateStatusBar();
       }
       

--- a/src/TraceWindow.html
+++ b/src/TraceWindow.html
@@ -13,7 +13,8 @@
             <div id="button-clear" class="button with-icon">Clear</div>
             <div id="button-pause" class="button with-icon">Pause</div>
             <div id="button-autoscroll" class="button with-icon active">Autoscroll</div>
-            <div id="button-filter" class="button with-icon active">Filter resources</div>
+            <div id="button-hide-resources" class="button with-icon active">Hide resources</div>
+            <div id="button-show-protocol-only" class="button with-icon">Show protocol requests only</div>
             <div id="button-colorize" class="button with-icon active">Colorize</div>
             <div id="button-export-list" class="button with-icon">Export</div>
             <div id="button-import-list" class="button with-icon">Import</div>

--- a/src/exportDialog.js
+++ b/src/exportDialog.js
@@ -23,17 +23,10 @@ ui = {
     }, true);
   },
 
-  setupContent: (requests, httpRequests, isFilteringActive) => {
+  setupContent: (httpRequests, hideResources, showProtocolRequestsOnly) => {
     // remember the currently captured (and filtered) requests
-    if (requests) {
-      let filteredRequests = requests.filter(req => {
-        let match = httpRequests.find(hr => hr.req.requestId === req.requestId);
-        if (match && (match.isVisible || !isFilteringActive)) {
-          return req;
-        }
-      });
-      ui.requests = filteredRequests;
-    }
+    filteredRequests = httpRequests?.filter(req => req.isVisible && req.isVisible(hideResources, showProtocolRequestsOnly)).map(req => req.parsed);
+    ui.requests = filteredRequests;
 
     const displayExportableRequestCount = () => {
       let requestCount = document.getElementById("request-count");

--- a/src/resources/css/buttons.css
+++ b/src/resources/css/buttons.css
@@ -42,10 +42,16 @@
 #button-autoscroll.button.active {
   background-image: var(--button-autoscroll-active);
 }
-#button-filter {
+#button-hide-resources {
   background-image: var(--button-filter-default);
 }
-#button-filter.button.active {
+#button-hide-resources.button.active {
+  background-image: var(--button-filter-active);
+}
+#button-show-protocol-only {
+  background-image: var(--button-filter-default);
+}
+#button-show-protocol-only.button.active {
   background-image: var(--button-filter-active);
 }
 #button-colorize {

--- a/src/resources/css/samltrace.css
+++ b/src/resources/css/samltrace.css
@@ -190,13 +190,14 @@ a.tab.selected:hover {
   color: var(--color-text-active);
   background-color: var(--color-line-selected);
 }
-.list-row.isResource {
-  height: 0;
-  border-bottom: none;
+.list-row.is-resource {
+  display: none;
 }
-.list-row.isResource.displayAnyway {
-  height: unset;
-  border-bottom: 1px solid var(--color-border);
+.list-row.show-resource {
+  display: flex;
+}
+.list-row.non-protocol {
+  display: none;
 }
 
 .request-method {

--- a/src/scrollableList.js
+++ b/src/scrollableList.js
@@ -6,7 +6,8 @@ if ("undefined" === typeof(ScrollableList)) {
   var ScrollableList = new function() {
 
     const isElementToBeSkipped = elem => {
-      return elem && elem.classList.contains("isResource") && !elem.classList.contains("displayAnyway");
+      const visibleInDom = elem.checkVisibility();
+      return !visibleInDom;
     };
 
     const getSibling = (cur, siblingFunc) => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -51,6 +51,25 @@ ui = {
     newState ? button.classList.add("active") : button.classList.remove("active");
   },
 
+  toggleListRowVisibility() {
+    const hideResources = document.getElementById("button-hide-resources").classList.contains("active");
+    const showProtocolRequestsOnly = document.getElementById("button-show-protocol-only").classList.contains("active");
+
+    Array.from(document.getElementsByClassName("list-row")).forEach(row => {
+      if (hideResources) {
+        row.classList.remove("show-resource");
+      } else {
+        row.classList.add("show-resource");
+      }
+      
+      if (showProtocolRequestsOnly && !row.classList.contains("is-protocol")) {
+        row.classList.add("non-protocol");
+      } else {
+        row.classList.remove("non-protocol");
+      }
+    });
+  },
+
   bindButtons: function() {
     document.getElementById("button-clear").addEventListener("click", () => {
       window.tracer.clearRequests();
@@ -67,15 +86,15 @@ ui = {
         requestList.scrollTop = requestList.scrollTopMax;
       }
     }, true);
-    document.getElementById("button-filter").addEventListener("click", e => {
-      let newState = ui.toggleButtonState(e.target);
-      window.tracer.setFilterResources(newState);
-      let hidableRows = document.getElementsByClassName("list-row isResource");
-      if (newState) {
-        Array.from(hidableRows).forEach(row => row.classList.remove("displayAnyway"));
-      } else {
-        Array.from(hidableRows).forEach(row => row.classList.add("displayAnyway"));
-      }
+    document.getElementById("button-hide-resources").addEventListener("click", e => {
+      const newState = ui.toggleButtonState(e.target);
+      window.tracer.setHideResources(newState);
+      ui.toggleListRowVisibility();
+    }, true);
+    document.getElementById("button-show-protocol-only").addEventListener("click", e => {
+      const newState = ui.toggleButtonState(e.target);
+      window.tracer.setShowProtocolOnly(newState);
+      ui.toggleListRowVisibility();
     }, true);
     document.getElementById("button-colorize").addEventListener("click", e => {
       let newState = ui.toggleButtonState(e.target);
@@ -90,9 +109,8 @@ ui = {
     document.getElementById("button-export-list").addEventListener("click", () => {
       let exportDialog = document.getElementById("exportDialog");
       exportDialog.style.visibility = "visible";
-      let isFilteringActive = document.getElementById("button-filter").classList.contains("active");
       let exportDialogContent = document.getElementById("exportDialogContent");
-      exportDialogContent.contentWindow.ui.setupContent(window.tracer.requests, window.tracer.httpRequests, isFilteringActive);
+      exportDialogContent.contentWindow.ui.setupContent(window.tracer.httpRequests, window.tracer.hideResources, window.tracer.showProtocolRequestsOnly);
     }, true);
     document.getElementById("button-import-list").addEventListener("click", () => {
       let importDialog = document.getElementById("importDialog");


### PR DESCRIPTION
This pull request solves issue #97.

While making these changes I realized that I created quite bunch of spaghetti code when I converted the web extension some years ago... 🙈 And I'm afraid by adding a second filter criteria I even added some noodles...

If I had more time, I'd be itching to rewrite the whole thing properly typed with TypeScript... But that's not very realistic due to the said lack of time 😄

Any way... As the PR changes a couple of lines and some logic I'd be glad if someone would find the time to test the changes. In particular, the export and import logic with and without activated filters. Before the release of a new version, I would feel better if it wasn't just me who had done a bit of testing.

BTW, some info what has changed in the UI:
The former button _Filter resources_ is now called _Hide resources_ which is a better term, I think, as it better describes that the filter is _exclusive_. And there's now the new button _Show protocol requests only_ which is not enabled by default.

![image](https://github.com/user-attachments/assets/73554365-e244-4777-b03d-0d3b8ece0c5f)
