### PR TITLE
Reference URLs to the extensions in extension stores and vice versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SAML-tracer
 ===========
 
-SAML-tracer is a browser extension, available from the Firefox and Chrome
+SAML-tracer is a browser extension, available from the [Firefox](https://addons.mozilla.org/en-US/firefox/addon/saml-tracer/) and [Chrome](https://chromewebstore.google.com/detail/mpdajninpobndbfcldcmbpnnbhibjmch)
 extension stores, that aims to make debugging of SAML- and 
 WS-Federation-communication between websites easier. 
 It is a request logger that in addition to showing normal requests, 

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,9 @@
       "strict_min_version": "121.0"
     }
   },
+  "chrome_settings_overrides": {
+    "homepage": "https://github.com/SimpleSAMLphp/SAML-tracer"
+  },
   "commands": {
     "_execute_action": {
       "suggested_key": {


### PR DESCRIPTION
For better cross checking between the actual extensions in stores to the project website I've added the references in both README and a Chrome specific override to include project homepage in the manifest file.

Initial [discussion](https://github.com/simplesamlphp/SAML-tracer/commit/c1d29a1bbb348d9f70087ed9869122717939dade#commitcomment-174005254).