### PR TITLE
Ship highlight.js verbatim from @highlightjs/cdn-assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@ lib/.gitkeep export-ignore
 node_modules/ export-ignore
 test/ export-ignore
 vendor/ export-ignore
-package-lock.json export-ignore
+# package-lock.json is deliberately kept in the release archive: it is the provenance record
+# for the third-party files in lib/, and AMO reviewers need it to verify them.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,24 +29,23 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install & build assets
-        run: |
-          # Make sure the lock-file is up to date before we run clean-install
-          npm install --package-lock-only
-          npm clean-install
-          npm audit fix
-
-      - name: Build custom (minimum) release of highlight.js
-        run: |
-          cd node_modules/highlight.js
-          npm install --package-lock-only
-          npm clean-install
-          npm run build
-          node tools/build.js xml properties http
+      - name: Install assets
+        # Deliberately a plain clean-install: package-lock.json is authoritative, so the
+        # published build is reproducible from the committed lock-file alone. Do not add
+        # `npm install --package-lock-only` or `npm audit fix` here -- both mutate the
+        # dependency tree at build time, which makes the shipped third-party files
+        # impossible for AMO reviewers to verify.
+        run: npm clean-install
 
       - name: Copy third-party dependencies to lib/ directory
+        # Copied verbatim from the @highlightjs/cdn-assets package, which is highlight.js'
+        # own published distribution. The files are byte-identical to that release, so a
+        # reviewer can verify them with `npm ci` and `diff` rather than reproducing a build.
         run: |
-          cp node_modules/highlight.js/build/highlight.min.js lib/highlight.min.js
+          cp node_modules/@highlightjs/cdn-assets/es/core.min.js lib/core.min.js
+          cp node_modules/@highlightjs/cdn-assets/es/languages/xml.min.js lib/xml.min.js
+          cp node_modules/@highlightjs/cdn-assets/es/languages/http.min.js lib/http.min.js
+          cp node_modules/@highlightjs/cdn-assets/es/languages/properties.min.js lib/properties.min.js
           cp node_modules/pako/dist/pako_inflate.min.js lib/pako_inflate.min.js
 
       - name: Clean release

--- a/attribution.md
+++ b/attribution.md
@@ -15,6 +15,11 @@ License type: BSD 3-clause "New" or "Revised" License
 
 Project URL: https://github.com/highlightjs/highlight.js
 
+Distribution: the files in `lib/` are copied verbatim, without modification, from the
+project's own published distribution package `@highlightjs/cdn-assets`, pinned to version
+11.11.1 in `package.json`. The exact tarball and its SHA-512 integrity hash are recorded in
+`package-lock.json`, so the shipped files can be verified with `npm ci` followed by `diff`.
+
 Original license text:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "saml-tracer",
       "version": "1.9.2",
       "dependencies": {
-        "highlight.js": "github:highlightjs/highlight.js",
+        "@highlightjs/cdn-assets": "11.11.1",
         "pako": "~2.2"
       },
       "devDependencies": {
@@ -510,6 +510,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@highlightjs/cdn-assets": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.11.1.tgz",
+      "integrity": "sha512-VEPdHzwelZ12hEX18BHduqxMZGolcUsrbeokHYxOUIm8X2+M7nx5QPtPeQgRxR9XjhdLv4/7DD5BWOlSrJ3k7Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1858,14 +1867,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "11.11.2",
-      "resolved": "git+ssh://git@github.com/highlightjs/highlight.js.git#5a5027abef61fad036db44b03ca2d8d0658bc3e4",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "highlight.js": "github:highlightjs/highlight.js",
+    "@highlightjs/cdn-assets": "11.11.1",
     "pako": "~2.2"
   },
   "devDependencies": {

--- a/src/TraceWindow.html
+++ b/src/TraceWindow.html
@@ -39,7 +39,7 @@
         </div>
 
         <script type="text/javascript" src="../lib/pako_inflate.min.js"></script>
-        <script type="text/javascript" src="../lib/highlight.min.js"></script>
+        <script type="module" src="hljs-init.js"></script>
         <script type="text/javascript" src="splitter.js"></script>
         <script type="text/javascript" src="hash.js"></script>
         <script type="text/javascript" src="SAMLTrace.js"></script>

--- a/src/hljs-init.js
+++ b/src/hljs-init.js
@@ -1,0 +1,16 @@
+// Registers the highlight.js grammars SAML-tracer uses and exposes hljs as a global,
+// so the classic (non-module) scripts on this page can keep calling hljs.highlightElement().
+//
+// The imported files are unmodified artifacts from the @highlightjs/cdn-assets package,
+// copied verbatim during the release build -- see .github/workflows/build-release.yml.
+// Only this wrapper is first-party code.
+import hljs from '../lib/core.min.js';
+import xml from '../lib/xml.min.js';
+import http from '../lib/http.min.js';
+import properties from '../lib/properties.min.js';
+
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('http', http);
+hljs.registerLanguage('properties', properties);
+
+window.hljs = hljs;


### PR DESCRIPTION
AMO's review of 1.9.4 is stuck on reproducing the minification of `lib/highlight.min.js`, and I don't think that's winnable while we ship a custom build. There's no official artifact to checksum against, so the reviewer is forced to reproduce a build, and ours was never reproducible in the first place: `package.json` pinned highlight.js to a bare GitHub URL with no ref, the workflow re-resolved it with `npm install --package-lock-only` before clean-install, `npm audit fix` ran immediately before the build, and `package-lock.json` was export-ignored out of the release archive. Nothing in the submitted zip identified a fixed version. Their build also died at `git rev-parse --short=10 HEAD` because they unpacked the source zip rather than cloning — hljs embeds the commit hash in the banner, so corrected instructions wouldn't have helped either.

So this consumes the project's own published distribution instead, pinned exactly, copied without modification. `@highlightjs/cdn-assets` is highlight.js' own npm package rather than a third-party CDN rehost, which matters for the "official site" rule — `package-lock.json` records the tarball URL and its SHA-512 integrity hash, so a reviewer verifies the shipped files with `npm ci` and `diff` and never has to build anything. I've also stopped export-ignoring the lock-file for that reason, and dropped `--package-lock-only` and `npm audit fix` from the workflow, since both mutate the dependency tree at build time and reintroduce exactly the problem we're trying to fix.

The `es/` modules give core plus only the xml, http and properties grammars, about 24 KB, slightly smaller than the custom build was. `src/hljs-init.js` is the only new first-party code: it imports those four files, registers the grammars and exposes `hljs` as a global so the page's classic scripts are untouched. It has to be a module script, but that's not a timing hazard — every `hljs` call site is event-driven, nothing runs at load. I verified in a loaded extension that `window.hljs` is defined, that exactly xml, http and properties are registered, that `versionString` is `11.11.1`, and that `highlightElement` still emits `hljs-` classes with no console errors.

One wrinkle worth flagging: cdn-assets has no 11.11.1 successor published yet, so this pins one patch behind the 11.11.2 the lock-file previously resolved to. I think a documentable downgrade beats an unreproducible build, but it's your call.

Refs #109.
